### PR TITLE
add mkdp_open_ip option

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -106,7 +106,8 @@ exports.run = function () {
         clients = {}
       }
       async function openBrowser ({ bufnr }) {
-        const openHost = openToTheWord ? getIP() : '127.0.0.1'
+        const openIp = await plugin.nvim.getVar('mkdp_open_ip')
+        const openHost = openIp !== '' ? openIp : (openToTheWord ? getIP() : '127.0.0.1')
         const url = `http://${openHost}:${port}/page/${bufnr}`
         const browserfunc = await plugin.nvim.getVar('mkdp_browserfunc')
         if (browserfunc !== '') {


### PR DESCRIPTION
When vim in virtual machine or back in proxy. Need set the open host ip.
```viml
let g:mkdp_open_to_the_world = 1
let g:mkdp_open_ip = '127.0.0.1'
let g:mkdp_port = 8080
function! g:Open_browser(url)
    silent exe '!lemonade open 'a:url
endfunction
let g:mkdp_browserfunc = 'g:Open_browser'
```

![dqrc7rtj2v](https://user-images.githubusercontent.com/1185757/51451099-a5fdea00-1d6e-11e9-827c-f41769ee5fac.gif)
