### PR TITLE
Add `<Plug>` preview toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,20 @@ let g:mkdp_port = ''
 let g:mkdp_page_title = '「${name}」'
 ```
 
+Mappings:
+
+```vim
+" normal/insert
+<Plug>MarkdownPreview
+<Plug>MarkdownPreviewStop
+<Plug>MarkdownPreviewToggle
+
+" example
+nmap <C-s> <Plug>MarkdownPreview
+nmap <M-s> <Plug>MarkdownPreviewStop
+nmap <C-p> <Plug>MarkdownPreviewToggle
+```
+
 Commands:
 
 ```vim

--- a/autoload/mkdp/util.vim
+++ b/autoload/mkdp/util.vim
@@ -174,3 +174,13 @@ function! mkdp#util#pre_build_version() abort
   return ''
 endfunction
 
+function! mkdp#util#toggle_preview() abort
+    if !get(b:, 'MarkdownPreviewToggleBool')
+        call mkdp#util#open_preview_page()
+        let b:MarkdownPreviewToggleBool=1
+    else
+        call mkdp#util#stop_preview()
+        let b:MarkdownPreviewToggleBool=0
+    endif
+endfunction
+

--- a/plugin/mkdp.vim
+++ b/plugin/mkdp.vim
@@ -90,19 +90,24 @@ endif
 
 function! s:init_command() abort
   " mapping for user
-  map <buffer> <silent> <Plug>MarkdownPreview :call mkdp#util#open_preview_page()<CR>
-  imap <buffer> <silent> <Plug>MarkdownPreview <Esc>:call mkdp#util#open_preview_page()<CR>a
-  map <buffer> <silent> <Plug>MarkdownPreviewStop :call mkdp#util#stop_preview()<CR>
-  imap <buffer> <silent> <Plug>MarkdownPreviewStop <Esc>:call mkdp#util#stop_preview()<CR>a
+  noremap <buffer> <silent> <Plug>MarkdownPreview :call mkdp#util#open_preview_page()<CR>
+  inoremap <buffer> <silent> <Plug>MarkdownPreview <Esc>:call mkdp#util#open_preview_page()<CR>a
+  noremap <buffer> <silent> <Plug>MarkdownPreviewStop :call mkdp#util#stop_preview()<CR>
+  inoremap <buffer> <silent> <Plug>MarkdownPreviewStop <Esc>:call mkdp#util#stop_preview()<CR>a
+  nnoremap <buffer> <silent> <Plug>MarkdownPreviewToggle :call mkdp#util#toggle_preview()<CR>
+  inoremap <buffer> <silent> <Plug>MarkdownPreviewToggle <Esc>:call mkdp#util#toggle_preview()<CR>
+endfunction
+
+function! s:MkdpAU() abort
+    command! -buffer MarkdownPreview call mkdp#util#open_preview_page()
+    call s:init_command()
 endfunction
 
 function! s:init() abort
   if g:mkdp_command_for_global
-    au BufEnter * command! -buffer MarkdownPreview call mkdp#util#open_preview_page()
-    call s:init_command()
+    au BufEnter * :call s:MkdpAU()
   else
-    au BufEnter *.{md,mkd,markdown,mdown,mkdn,mdwn} command! -buffer MarkdownPreview call mkdp#util#open_preview_page()
-    call s:init_command()
+    au BufEnter *.{md,mkd,markdown,mdown,mkdn,mdwn} :call s:MkdpAU()
   endif
   if g:mkdp_auto_start
     au BufEnter *.{md,mkd,markdown,mdown,mkdn,mdwn} call mkdp#util#open_preview_page()


### PR DESCRIPTION
# This solves [#49](https://github.com/iamcco/markdown-preview.nvim/issues/49)

## Todo
- [x] Add steps to readme

## Changes

* Adds a `<Plug>` mapping for toggling preview

```vim
<Plug>MarkdownPreviewToggle
```

* Change the default `map` for their non-recursive version `noremap`.

This will not collide with other mappings the user may have. Also limit the
mappings to `normal` by :point_right: `(n)noremap`

* Fix the `<Plug>` mappings that were only available at `startup` for the
initial buffer.

With this change when the user enter one of these
`*.{md,mkd,markdown,mdown,mkdn,mdwn}` the `<Plug>` mappings will be available.
Below are two examples.

Before:

[![asciicast](https://asciinema.org/a/Gwx7VnSsjYwjbOVyzIzHLF4GA.svg)](https://asciinema.org/a/Gwx7VnSsjYwjbOVyzIzHLF4GA)

After:

[![asciicast](https://asciinema.org/a/7shshWJqhnLuWcapxR2ZrVqkX.svg)](https://asciinema.org/a/7shshWJqhnLuWcapxR2ZrVqkX)