### PR TITLE
fix(readme): fix installation guide for dein

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Or install with [dein](https://github.com/Shougo/dein.vim):
 
 ```vim
 call dein#add('iamcco/markdown-preview.nvim', {'on_ft': ['markdown', 'pandoc.markdown', 'rmd'],
-					\ 'build': 'cd app & yarn install' })
+					\ 'build': 'sh -c "cd app & yarn install"' })
 ```
 
 Config:


### PR DESCRIPTION
The original way to install this plugin is unavailable.

Dein document describes as follows:

> Note: The command is executed in plugin top directory.
		If you need cd command, you must use "sh -c". >
		call dein#add('wincent/command-t', {
		\ 'build':
		\      'sh -c "cd ruby/command-t && ruby extconf.rb && make"'
		\ })
