### PR TITLE
Support for block ```{.plantuml

### DIFF
--- a/app/pages/plantuml.js
+++ b/app/pages/plantuml.js
@@ -20,7 +20,7 @@ export default (md, opts = {}) => {
   md.renderer.rules.fence = (tokens, idx, options, env, slf) => {
     const token = tokens[idx]
     try {
-      if (token.info && token.info.trim() === 'plantuml') {
+      if (token.info && token.info.indexOf('plantuml') != -1 ) {
         const code = token.content.trim()
         return `<img src="${generateSourceDefault(code, opts)}" alt="" />`
       }


### PR DESCRIPTION
I usually write design documents using markdown and plantuml. Then I export the documents to PDF format using `pandoc`. There is a `pandoc` filter to support blocks of plantuml (`` ```plantuml``). But this filter also supports to pass attributes to pandoc directly in the block.
`` ```{.plantuml caption="title" width=40%}``

When I use this last form to define the plantuml block, this plugin doesn't recognize it. This pull requests tries to solve this.