### PR TITLE
chore(readme): add examples for custom css options

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,11 @@ let g:mkdp_preview_options = {
     \ }
 
 " use a custom markdown style must be absolute path
+" like '/Users/username/markdown.css' or expand('~/markdown.css')
 let g:mkdp_markdown_css = ''
 
 " use a custom highlight style must absolute path
+" like '/Users/username/highlight.css' or expand('~/highlight.css')
 let g:mkdp_highlight_css = ''
 
 " use a custom port to start server or random for empty


### PR DESCRIPTION
从我的经历来看，文档中目前的解释 `absolute path` 不能很直观地看出来是要配置一个文件路径还是一个 URL，给一些例子能更好的理解。

另外现在有很多人使用 git 管理 Vim 配置，需要提示一种跨平台适用的写法，比如 `expand('~/markdown.css')`。

以上，望采纳。