### PR TITLE
feat(local image): support relative path start with '/' or '\'

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -71,6 +71,16 @@ use(async (req, res, next) => {
       imgPath = imgPath.replace(/\\ /g, ' ')
       if (imgPath[0] !== '/' && imgPath[0] !== '\\') {
         imgPath = path.join(fileDir, imgPath)
+      } else if (!fs.existsSync(imgPath)) {
+        let tmpDirPath = fileDir
+        while (tmpDirPath !== '/' && tmpDirPath !== '\\') {
+          tmpDirPath = path.normalize(path.join(tmpDirPath, '..'))
+          let tmpImgPath = path.join(tmpDirPath, imgPath)
+          if (fs.existsSync(tmpImgPath)) {
+            imgPath = tmpImgPath
+            break
+          }
+        }
       }
       logger.info('imgPath', imgPath)
       if (fs.existsSync(imgPath)) {


### PR DESCRIPTION
这个 PR 是兼容我的使用场景下的本地图片预览问题。

我经常使用到这个插件的一个场景是写托管在 GitHub Pages 的博客（基于 Jekyll），我的文件树示意如下：

```
│
├── _posts
│     └── blog
│           └── 2020-04-18-example.md
└── images
      └── blog
            └── wudaokou.jpg
```

我这个时候要编辑 2020-04-18-example.md 这个文件，然后我要在里面展示 wudaokou.jpg 这个图片，因为 Jekyll 编译过后，页面的路径会发生变化，所以不可以使用 Markdown 和 jpg 文件的相对路径来引用图片，所以目前使用本插件无法正常预览图片。我会这样写：

```markdown
![](/images/blog/wudaokou.jpg)
```

从 HTTP 层面来说它是一个基于博客域名的绝对路径，但是在本地预览时，它是一个相对于某一个文件路径（比如代码根目录）的相对路径。

使用 GitHub Pages 和 Jekyll 写博客的朋友不少，相信这个场景还是比较普遍的。目前我尝试过的编辑器中，VSCode + 插件 Markdown Preview Enhanced 是可以正常预览的。

针对这种情况，我做了如下思路的兼容处理：

1. 相对于 Markdown 文件的上一级目录 A，看该路径对应的图片是否存在；
2. 否则回溯到 A 的上一级目录 B，看相对于 B，该路径对应的图片是否存在；
3. 否则回溯到 B 的上一级目录 C，看相对于 C，该路径对应的图片是否存在；
4. ...

依此类推，直到找到图片，或者回溯到根目录为止。

在我的场景下测试目前已能正常预览，且不影响原有预览本地图片逻辑。

![image](https://user-images.githubusercontent.com/1646590/79637942-74fca700-81b5-11ea-9705-f0fd150da4d1.png)

望采纳。