### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ Install with [vim-plug](https://github.com/junegunn/vim-plug):
 
 ```vim
 " If you don't have nodejs and yarn
-" use pre build
-Plug 'iamcco/markdown-preview.nvim', { 'do': { -> mkdp#util#install() } }
+" use pre build, add 'vim-plug' to the filetype list so vim-plug can update this plugin
+" see: https://github.com/iamcco/markdown-preview.nvim/issues/50
+Plug 'iamcco/markdown-preview.nvim', { 'do': { -> mkdp#util#install() }, 'for': ['markdown', 'vim-plug']}
+
 
 " If you have nodejs and yarn
 Plug 'iamcco/markdown-preview.nvim', { 'do': 'cd app & yarn install'  }


### PR DESCRIPTION
Update installation for the prebuild version of the plugin using vim plug. To include instructions from
https://github.com/iamcco/markdown-preview.nvim/issues/50.