### PR TITLE
Changed autocmd check to &filetype instead of filename

### DIFF
--- a/plugin/mkdp.vim
+++ b/plugin/mkdp.vim
@@ -112,7 +112,7 @@ function! s:init() abort
     if g:mkdp_command_for_global
       autocmd BufEnter * :call s:MkdpAU()
     else
-      autocmd BufEnter *.{md,mkd,markdown,mdown,mkdn,mdwn} :call s:MkdpAU()
+      autocmd BufEnter * if &filetype ==# 'markdown' | call s:MkdpAU() | endif
     endif
     if g:mkdp_auto_start
       autocmd BufEnter *.{md,mkd,markdown,mdown,mkdn,mdwn} call mkdp#util#open_preview_page()


### PR DESCRIPTION
When we start a new empty buffer, and then `set filetype=markdown`, `:MarkdownPreview` is not available.
This fixes that.