### PR TITLE
Disable filename option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ let g:mkdp_browserfunc = ''
 " hide_yaml_meta: if hide yaml metadata, default is 1
 " sequence_diagrams: js-sequence-diagrams options
 " content_editable: if enable content editable for preview page, default: v:false
+" disable_filename: if disable filename header for preview page, default: 0
 let g:mkdp_preview_options = {
     \ 'mkit': {},
     \ 'katex': {},
@@ -128,7 +129,8 @@ let g:mkdp_preview_options = {
     \ 'hide_yaml_meta': 1,
     \ 'sequence_diagrams': {},
     \ 'flowchart_diagrams': {},
-    \ 'content_editable': v:false
+    \ 'content_editable': v:false,
+    \ 'disable_filename': 0
     \ }
 
 " use a custom markdown style must be absolute path

--- a/app/pages/index.jsx
+++ b/app/pages/index.jsx
@@ -189,7 +189,8 @@ export default class PreviewPage extends React.Component {
       })(name),
       content: this.md.render(content.join('\n')),
       pageTitle,
-      contentEditable: options.content_editable
+      contentEditable: options.content_editable,
+      disableFilename: options.disable_filename
     }, () => {
       try {
         // eslint-disable-next-line
@@ -215,7 +216,7 @@ export default class PreviewPage extends React.Component {
   }
 
   render() {
-    const { content, name, pageTitle, contentEditable } = this.state
+    const { content, name, pageTitle, contentEditable, disableFilename } = this.state
     return (
       <React.Fragment>
         <Head>
@@ -240,24 +241,26 @@ export default class PreviewPage extends React.Component {
           <script type="text/javascript" src="/_static/full.render.js"></script>
         </Head>
         <div id="page-ctn" contentEditable={contentEditable ? 'true' : 'false'}>
-          <header id="page-header">
-            <h3>
-              <svg
-                viewBox="0 0 16 16"
-                version="1.1"
-                width="16"
-                height="16"
-                aria-hidden="true"
-              >
-                <path
-                  fill-rule="evenodd"
-                  d="M3 5h4v1H3V5zm0 3h4V7H3v1zm0 2h4V9H3v1zm11-5h-4v1h4V5zm0 2h-4v1h4V7zm0 2h-4v1h4V9zm2-6v9c0 .55-.45 1-1 1H9.5l-1 1-1-1H2c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h5.5l1 1 1-1H15c.55 0 1 .45 1 1zm-8 .5L7.5 3H2v9h6V3.5zm7-.5H9.5l-.5.5V12h6V3z"
+          { !disableFilename &&
+            <header id="page-header">
+              <h3>
+                <svg
+                  viewBox="0 0 16 16"
+                  version="1.1"
+                  width="16"
+                  height="16"
+                  aria-hidden="true"
                 >
-                </path>
-              </svg>
-              {name}
-            </h3>
-          </header>
+                  <path
+                    fill-rule="evenodd"
+                    d="M3 5h4v1H3V5zm0 3h4V7H3v1zm0 2h4V9H3v1zm11-5h-4v1h4V5zm0 2h-4v1h4V7zm0 2h-4v1h4V9zm2-6v9c0 .55-.45 1-1 1H9.5l-1 1-1-1H2c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h5.5l1 1 1-1H15c.55 0 1 .45 1 1zm-8 .5L7.5 3H2v9h6V3.5zm7-.5H9.5l-.5.5V12h6V3z"
+                  >
+                  </path>
+                </svg>
+                {name}
+              </h3>
+            </header>
+          }
           <section
             className="markdown-body"
             dangerouslySetInnerHTML={{

--- a/plugin/mkdp.vim
+++ b/plugin/mkdp.vim
@@ -67,7 +67,8 @@ if !exists('g:mkdp_preview_options')
       \ 'hide_yaml_meta': 1,
       \ 'sequence_diagrams': {},
       \ 'flowchart_diagrams': {},
-      \ 'content_editable': v:false
+      \ 'content_editable': v:false,
+      \ 'disable_filename': 0
       \ }
 endif
 


### PR DESCRIPTION
# Solves #147 

## Changes
- Adds `disable_filename` as a markdown render option in the `mkdp_preview_options` variable
- Using react-style conditional rendering this controls whether or not the page will display the filename at the top
- Updated the README to include the new option

### Notes
- I chose the variable name based off of what sounded like it made sense, I can change it if there is a better, more clear name
- I tested out multiple cases and it built/worked fine to my knowledge