### PR TITLE
Always set MarkdownPreviewToggleBool = 0 on close

### DIFF
--- a/autoload/mkdp/rpc.vim
+++ b/autoload/mkdp/rpc.vim
@@ -119,6 +119,7 @@ function! mkdp#rpc#stop_server() abort
     let s:mkdp_channel_id = -1
     let g:mkdp_node_channel_id = -1
   endif
+  let b:MarkdownPreviewToggleBool = 0
 endfunction
 
 function! mkdp#rpc#get_server_status() abort
@@ -150,6 +151,7 @@ function! mkdp#rpc#preview_close() abort
       call rpcnotify(g:mkdp_node_channel_id, 'close_page', { 'bufnr': bufnr('%') })
     endif
   endif
+  let b:MarkdownPreviewToggleBool = 0
   call mkdp#autocmd#clear_buf()
 endfunction
 


### PR DESCRIPTION
Fixes #237 

Did not find a unified function that is always called on preview close. So I had to set the variable to 0 twice in the code.