### PR TITLE
Don't Show File Header while Page is Loading

### DIFF
--- a/app/pages/index.jsx
+++ b/app/pages/index.jsx
@@ -79,7 +79,8 @@ export default class PreviewPage extends React.Component {
       cursor: '',
       content: '',
       pageTitle: '',
-      contentEditable: false
+      contentEditable: false,
+      disableFilename: 1
     }
   }
 
@@ -241,7 +242,7 @@ export default class PreviewPage extends React.Component {
           <script type="text/javascript" src="/_static/full.render.js"></script>
         </Head>
         <div id="page-ctn" contentEditable={contentEditable ? 'true' : 'false'}>
-          { !disableFilename &&
+          { disableFilename == 0 &&
             <header id="page-header">
               <h3>
                 <svg

--- a/plugin/mkdp.vim
+++ b/plugin/mkdp.vim
@@ -70,6 +70,8 @@ if !exists('g:mkdp_preview_options')
       \ 'content_editable': v:false,
       \ 'disable_filename': 0
       \ }
+elseif !has_key(g:mkdp_preview_options, 'disable_filename')
+  let g:mkdp_preview_options['disable_filename'] = 0
 endif
 
 " markdown css file absolute path


### PR DESCRIPTION
# Fix in response to [comment](https://github.com/iamcco/markdown-preview.nvim/issues/147#issuecomment-705804075)

## Changes
- Makes explicit check to see if `disableFilename == 0`
- Added 'elseif' clause to if statement in `plugins/mkdp.vim` to check whether the `disable_filename` option had been set, if not I set it to 0. This was to avoid header rendering errors with existing user configurations.

## Notes
- The filename header is now effectively disabled while the page is loading, then, once loaded, the option `disable_filename` should be resolved and will either have the default value `0` or the value set by the user in their vimrc. 
- If the users `g:mkdp_preview_options` does not set `disable_filename` then the plugin will automatically set its value to `0`.