### PR TITLE
Add pkg as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@types/node": "^10.11.7",
     "markdown-it-deflist": "^2.0.3",
+    "pkg": "^4.4.9",
     "prettier": "^1.14.3",
     "tslint": "^5.17.0",
     "tslint-config-prettier": "^1.18.0",


### PR DESCRIPTION
pkg obviously is required for building the plugin. It should be a dev dependency then, because the OS suggestions might be confusing: 
![image](https://user-images.githubusercontent.com/1249745/97105473-35120180-16bb-11eb-956e-1621975ea4b3.png)
