### PR TITLE
fix wsl2 detection

### DIFF
--- a/app/lib/util/opener.js
+++ b/app/lib/util/opener.js
@@ -14,7 +14,7 @@ module.exports = function opener(args, tool) {
     // this specific case we need to treat it as actually being Windows.
     // The "Windows-way" of opening things through cmd.exe works just fine here,
     // whereas using xdg-open does not, since there is no X Windows in WSL.
-    if (platform === 'linux' && os_1.default.release().indexOf('Microsoft') !== -1) {
+    if (platform === 'linux' && os_1.default.release().toLowerCase().indexOf('microsoft') !== -1) {
         platform = 'win32';
     }
     // http://stackoverflow.com/q/1480971/3191, but see below for Windows.

--- a/src/util/opener.ts
+++ b/src/util/opener.ts
@@ -16,7 +16,7 @@ module.exports = function opener(
   // this specific case we need to treat it as actually being Windows.
   // The "Windows-way" of opening things through cmd.exe works just fine here,
   // whereas using xdg-open does not, since there is no X Windows in WSL.
-  if (platform === 'linux' && os.release().indexOf('Microsoft') !== -1) {
+  if (platform === 'linux' && os.release().toLowerCase().indexOf('microsoft') !== -1) {
     platform = 'win32'
   }
 


### PR DESCRIPTION
Hi,
I  kept getting the error "_Can not open browser by using xdg-open command_" while working developing with nvim under windows wsl2 - ubuntu 20.04.

Figured out it was a casing issue. The app was checking for 'Microsoft'.

Here is the output of node for the current environment in wsl2:

```
Welcome to Node.js v14.12.0.
Type ".help" for more information.
> require('os').release()
'4.19.128-microsoft-standard'
> process.platform
'linux'
```
Notice the lower case `microsoft`.