### PR TITLE
Add a dark scheme option (set with prefers-color-scheme)

### DIFF
--- a/app/_static/highlight.css
+++ b/app/_static/highlight.css
@@ -3,10 +3,8 @@
 github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
 */
-@media (prefers-color-scheme: light) {
-    :root {
-        --color-text-primary: #333;
-    }
+:root {
+    --color-text-primary: #333;
 }
 @media (prefers-color-scheme: dark) {
     :root {

--- a/app/_static/highlight.css
+++ b/app/_static/highlight.css
@@ -3,12 +3,22 @@
 github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
 */
+@media (prefers-color-scheme: light) {
+    :root {
+        --color-text-primary: #333;
+    }
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --color-text-primary: #c9d1d9;
+    }
+}
 
 .hljs {
   display: block;
   overflow-x: auto;
   padding: 0.5em;
-  color: #333;
+  color: var(--color-text-primary);
   background: #f8f8f8;
 }
 
@@ -21,7 +31,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-keyword,
 .hljs-selector-tag,
 .hljs-subst {
-  color: #333;
+  color: var(--color-text-primary);
   font-weight: bold;
 }
 

--- a/app/_static/markdown.css
+++ b/app/_static/markdown.css
@@ -8,12 +8,15 @@
     --color-text-tertiary: #777;
     --color-text-link: #4078c0;
     --color-bg-primary: #fff;
+    --color-bg-secondary: #fafbfc;
+    --color-bg-tertiary: #f8f8f8;
     --color-border-primary: #ddd;
     --color-border-secondary: #eaecef;
+    --color-border-tertiary: #d1d5da;
+    --color-kbd-foreground: #444d56;
     --color-markdown-blockquote-border: #dfe2e5;
     --color-markdown-table-border: #dfe2e5;
     --color-markdown-table-tr-border: #c6cbd1;
-    --color-bg-tertiary: #f8f8f8;
     --color-markdown-code-bg: #1b1f230d;
 }
 @media (prefers-color-scheme: dark) {
@@ -22,12 +25,15 @@
         --color-text-tertiary: #8b949e;
         --color-text-link: #58a6ff;
         --color-bg-primary: #0d1117;
+        --color-bg-secondary: #0d1117;
+        --color-bg-tertiary: #161b22;
         --color-border-primary: #30363d;
         --color-border-secondary: #21262d;
+        --color-border-tertiary: #6e7681;
+        --color-kbd-foreground: #b1bac4;
         --color-markdown-blockquote-border: #3b434b;
         --color-markdown-table-border: #3b434b;
         --color-markdown-table-tr-border: #272c32;
-        --color-bg-tertiary: #161b22;
         --color-markdown-code-bg: #f0f6fc26;
     }
 }
@@ -211,12 +217,12 @@
   padding: 5px 6px;
   font: 14px SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
   line-height: 10px;
-  color: #444d56;
+  color: var(--color-kbd-foreground);
   vertical-align: middle;
-  background-color: #fafbfc;
-  border: 1px solid #d1d5da;
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-tertiary);
   border-radius: 3px;
-  box-shadow: inset 0 -1px 0 #d1d5da;
+  box-shadow: inset 0 -1px 0 var(--color-border-tertiary);
 }
 .markdown-body pre {
   word-wrap: normal;

--- a/app/_static/markdown.css
+++ b/app/_static/markdown.css
@@ -2,6 +2,36 @@
  * github like style
  * https://github.com/iamcco/markdown.css/blob/master/dest/github/markdown.css
  */
+
+:root {
+    --color-text-primary: #333;
+    --color-text-tertiary: #777;
+    --color-text-link: #4078c0;
+    --color-bg-primary: #fff;
+    --color-border-primary: #ddd;
+    --color-border-secondary: #eaecef;
+    --color-markdown-blockquote-border: #dfe2e5;
+    --color-markdown-table-border: #dfe2e5;
+    --color-markdown-table-tr-border: #c6cbd1;
+    --color-bg-tertiary: #f8f8f8;
+    --color-markdown-code-bg: #1b1f230d;
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --color-text-primary: #c9d1d9;
+        --color-text-tertiary: #8b949e;
+        --color-text-link: #58a6ff;
+        --color-bg-primary: #0d1117;
+        --color-border-primary: #30363d;
+        --color-border-secondary: #21262d;
+        --color-markdown-blockquote-border: #3b434b;
+        --color-markdown-table-border: #3b434b;
+        --color-markdown-table-tr-border: #272c32;
+        --color-bg-tertiary: #161b22;
+        --color-markdown-code-bg: #f0f6fc26;
+    }
+}
+
 .markdown-body ol ol,
 .markdown-body ul ol,
 .markdown-body ol ul,
@@ -16,12 +46,12 @@
 .markdown-body {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 16px;
-  color: #333;
+  color: var(--color-text-primary);
   line-height: 1.6;
   word-wrap: break-word;
   padding: 45px;
-  background: #fff;
-  border: 1px solid #ddd;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-primary);
   -webkit-border-radius: 0 0 3px 3px;
   border-radius: 0 0 3px 3px;
 }
@@ -85,13 +115,13 @@
   padding-bottom: 0.3em;
   font-size: 2.25em;
   line-height: 1.2;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-secondary);
 }
 .markdown-body h2 {
   padding-bottom: 0.3em;
   font-size: 1.75em;
   line-height: 1.225;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-border-secondary);
 }
 .markdown-body h3 {
   font-size: 1.5em;
@@ -105,14 +135,14 @@
 }
 .markdown-body h6 {
   font-size: 1em;
-  color: #777;
+  color: var(--color-text-tertiary);
 }
 .markdown-body hr {
   margin-top: 20px;
   margin-bottom: 20px;
   height: 0;
   border: 0;
-  border-top: 1px solid #eee;
+  border-top: 1px solid var(--color-border-primary);
 }
 .markdown-body ol,
 .markdown-body ul {
@@ -152,8 +182,8 @@
   margin-left: 0;
   margin-right: 0;
   padding: 0 15px;
-  color: #777;
-  border-left: 4px solid #ddd;
+  color: var(--color-text-tertiary);
+  border-left: 4px solid var(--color-markdown-blockquote-border);
 }
 .markdown-body table {
   display: block;
@@ -165,16 +195,16 @@
   border-spacing: 0;
 }
 .markdown-body table tr {
-  background-color: #fff;
-  border-top: 1px solid #ccc;
+  background-color: var(--color-bg-primary);
+  border-top: 1px solid var(--color-markdown-table-tr-border);
 }
 .markdown-body table tr:nth-child(2n) {
-  background-color: #f8f8f8;
+  background-color: var(--color-bg-tertiary);
 }
 .markdown-body table th,
 .markdown-body table td {
   padding: 6px 13px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-markdown-table-border);
 }
 .markdown-body kbd {
   display: inline-block;
@@ -194,7 +224,7 @@
   overflow: auto;
   font-size: 85%;
   line-height: 1.45;
-  background-color: #f7f7f7;
+  background-color: var(--color-bg-tertiary);
   -webkit-border-radius: 3px;
   border-radius: 3px;
 }
@@ -224,7 +254,7 @@
   padding-bottom: 0.2em;
   margin: 0;
   font-size: 85%;
-  background-color: rgba(0,0,0,0.04);
+  background-color: var(--color-markdown-code-bg);
   -webkit-border-radius: 3px;
   border-radius: 3px;
 }
@@ -234,7 +264,7 @@
   content: "\00a0";
 }
 .markdown-body a {
-  color: #4078c0;
+  color: var(--color-text-link);
   text-decoration: none;
   background: transparent;
 }

--- a/app/_static/page.css
+++ b/app/_static/page.css
@@ -1,13 +1,26 @@
+:root {
+    --foreground-color: #24292e;
+    --background-color: #f6f8fa;
+    --border-color: #d1d5da;
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --foreground-color: #c9d1d9;
+        --background-color: #0d1117;
+        --border-color: #30363d;
+    }
+}
+
 #page-ctn {
   margin: 0 auto;
   max-width: 900px;
-  color: #24292e;
+  color: var(--foreground-color);
 }
 
 #page-header {
   padding: 8px;
-  background-color: #f6f8fa;
-  border-color: #d1d5da;
+  background-color: var(--background-color);
+  border-color: var(--border-color);
   border-style: solid;
   border-width: 1px 1px 0;
   border-top-left-radius: 3px;


### PR DESCRIPTION
Hey!

I've been loving using this plugin so far, but it was missing a dark scheme option.

I refactored the colors into css variables.
They're first set to the light scheme (which is exactly the colors which were in use before), so users with `prefers-color-scheme` either set to `light` or not set at all get this scheme.
Then, if `prefers-color-scheme` is set to `dark`, the variables will be changed to their dark variants (the same color scheme github uses on their dark mode).

Preview:
![dark](https://u.cubeupload.com/Misterio77x/baba.png)
![light](https://u.cubeupload.com/Misterio77x/b.png)

Fixes #297