### PR TITLE
Changing auto close event to BufHidden

### DIFF
--- a/autoload/mkdp/autocmd.vim
+++ b/autoload/mkdp/autocmd.vim
@@ -10,7 +10,7 @@ function! mkdp#autocmd#init() abort
     endif
     " autoclose autocmd
     if g:mkdp_auto_close
-      autocmd BufLeave <buffer> call mkdp#rpc#preview_close()
+      autocmd BufHidden <buffer> call mkdp#rpc#preview_close()
     endif
     " server close autocmd
     autocmd VimLeave * call mkdp#rpc#stop_server()


### PR DESCRIPTION
BufLeave triggers the event even when switching to different files or tabs inside Vim.
BufHidden provides a better alternative as it works more like it's expected (BufDelete can't be used because the buffer is not deleted right after a file is closed)