### PR TITLE
update:for Darwin arm64

### DIFF
--- a/app/install.sh
+++ b/app/install.sh
@@ -80,5 +80,6 @@ case "${arch}" in
   "Linux x86_64") download markdown-preview-linux.tar.gz ;;
   "Linux i686") download markdown-preview-linux.tar.gz ;;
   "Darwin x86_64") download markdown-preview-macos.tar.gz ;;
+  "Darwin arm64") download markdown-preview-macos.tar.gz ;;
   *) info "No pre-built binary available for ${arch}.";;
 esac


### PR DESCRIPTION
For MacOS with arm64 arch (M1 chip), the plugin can also use 'markdown-preview-macos' binary file and the plugin will work properly.