### PR TITLE
修复：macos（m1）无法正确安装。

### DIFF
--- a/app/install.sh
+++ b/app/install.sh
@@ -80,5 +80,6 @@ case "${arch}" in
   "Linux x86_64") download markdown-preview-linux.tar.gz ;;
   "Linux i686") download markdown-preview-linux.tar.gz ;;
   "Darwin x86_64") download markdown-preview-macos.tar.gz ;;
+  "Darwin arm64") download markdown-preview-macos.tar.gz ;;
   *) info "No pre-built binary available for ${arch}.";;
 esac


### PR DESCRIPTION
Add Darwin arm64 to the judgment of arch in the downlaod() of
install.sh.
