### PR TITLE
Vertical-alignment in table cells

### DIFF
--- a/app/_static/markdown.css
+++ b/app/_static/markdown.css
@@ -209,6 +209,7 @@
 .markdown-body table td {
   padding: 6px 13px;
   border: 1px solid var(--color-markdown-table-border);
+  vertical-align: top;
 }
 .markdown-body kbd {
   display: inline-block;


### PR DESCRIPTION
So you can just do something like this in standard Github-flavoured markdown...

```
| Item Column Heading | Description Column Heading                 |
|---------------------|--------------------------------------------|
| Item 1              | Description Line 1<br/>Description Line 2  |
```

At present you have to do something like this:

```
| Item Column Heading | Description Column Heading                 |
|---------------------|--------------------------------------------|
| Item 1<br/>&nbsp;   | Description Line 1<br/>Description Line 2  |
```