### PR TITLE
Set the font-family on header text to match markdown default

### DIFF
--- a/app/_static/page.css
+++ b/app/_static/page.css
@@ -55,6 +55,7 @@ main {
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
   line-height: 24px;
+  font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
 #page-header svg {


### PR DESCRIPTION
There is no font family set on the header text so we see a basic serif font depending on browser default styles. This PR adds a font family that matches what is in `markdown.css`. I think this looks better. Feel free to close it if you don't!

<img width="1396" alt="Screen Shot 2022-03-29 at 4 35 02 PM" src="https://user-images.githubusercontent.com/5800836/160712341-2edc1ac6-9aa8-4803-b06b-b3f5c016d55c.png">

<img width="1396" alt="Screen Shot 2022-03-29 at 4 37 30 PM" src="https://user-images.githubusercontent.com/5800836/160712350-ba51b8f9-3e93-4b9b-8c9d-294bf2e4d38e.png">

