### PR TITLE
fix: add fallback address $NVIM

### DIFF
--- a/app/nvim.js
+++ b/app/nvim.js
@@ -1,6 +1,6 @@
 const attach = require('./lib/attach').default
 const logger = require('./lib/util/logger')('app/nvim')
-const address = process.env.MKDP_NVIM_LISTEN_ADDRESS || process.env.NVIM_LISTEN_ADDRESS || '/tmp/nvim'
+const address = process.env.MKDP_NVIM_LISTEN_ADDRESS || process.env.NVIM_LISTEN_ADDRESS || process.env.NVIM || '/tmp/nvim'
 
 const MSG_PREFIX = '[markdown-preview.nvim]'
 


### PR DESCRIPTION
neovim 0.8.0 makes breaking changes in
[PR #11009](https://github.com/neovim/neovim/pull/11009).
This PR replace variable `$NVIM_LISTEN_ADDRESS` with `$NVIM`.

Fixed: #452 