### PR TITLE
Feature: Automatically switch mermaid theme if not defined in options

### DIFF
--- a/app/pages/index.jsx
+++ b/app/pages/index.jsx
@@ -262,7 +262,7 @@ export default class PreviewPage extends React.Component {
         if (refreshContent) {
           try {
             // eslint-disable-next-line
-            mermaid.initialize(options.maid || {})
+            mermaid.initialize({ theme: (this.state.theme || 'light'), ...(options.maid || {}) })
             // eslint-disable-next-line
             mermaid.init(undefined, document.querySelectorAll('.mermaid'))
           } catch (e) { }


### PR DESCRIPTION
Adding ability to automatically change theme in mermaid (between light and dark) depending on global theme, if not specified in mermaid options:

```
let g:mkdp_preview_options = {
    \ 'maid': { ... },
}
```

https://user-images.githubusercontent.com/37133/216698791-48c86873-112f-4b06-a59f-9aa3aa79fec8.mov


