### PR TITLE
fix(script): install.sh

### DIFF
--- a/app/install.sh
+++ b/app/install.sh
@@ -1,7 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o nounset    # error when referencing undefined variable
 set -o errexit    # exit when command fails
+
+# goes to the script directory
+cd "$(dirname "$0")"
 
 BOLD="$(tput bold 2>/dev/null || echo '')"
 GREY="$(tput setaf 0 2>/dev/null || echo '')"
@@ -68,7 +71,7 @@ download() {
   url="https://github.com/iamcco/markdown-preview.nvim/releases/download/$tag/${1}"
   info "Downloading binary from ${url}"
   if fetch "${url}" | tar xzfv -; then
-    chmod a+x ${1%.tar.gz}
+    chmod a+x "${1%.tar.gz}"
     return
   else
     warn "Binary not available for now, please wait for a few minutes."


### PR DESCRIPTION
1. cd to the script directory first, so `./app/install.sh` won't install binary into wrong directory
2. use bash instead of sh, features like nounset are bash only
3. double quote variables