### PR TITLE
cache bufnr to prevent error while processing autoclose autocmd

### DIFF
--- a/app/_static/highlight.css
+++ b/app/_static/highlight.css
@@ -5,9 +5,13 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 */
 :root {
     --color-text-primary: #333;
+    --color-diff-add: #dfd;
+    --color-diff-remove: #fdd;
 }
 [data-theme="dark"] {
     --color-text-primary: #c9d1d9;
+    --color-diff-add: #484;
+    --color-diff-remove: #844;
 }
 
 .hljs {
@@ -89,11 +93,11 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 }
 
 .hljs-deletion {
-  background: #fdd;
+  background: var(--color-diff-remove);
 }
 
 .hljs-addition {
-  background: #dfd;
+  background: var(--color-diff-add);
 }
 
 .hljs-emphasis {

--- a/app/_static/markdown.css
+++ b/app/_static/markdown.css
@@ -253,7 +253,6 @@
   content: normal;
 }
 .markdown-body code {
-  font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
   padding: 0;
   padding-top: 0.2em;
   padding-bottom: 0.2em;

--- a/app/_static/markdown.css
+++ b/app/_static/markdown.css
@@ -302,6 +302,9 @@
   box-sizing: border-box;
   padding: 0;
 }
+.task-list-item input[type="checkbox"]:checked {
+  filter: invert() brightness(2.5) invert();
+}
 .task-list-item input[type="radio"] {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;

--- a/app/_static/markdown.css
+++ b/app/_static/markdown.css
@@ -309,3 +309,13 @@
   box-sizing: border-box;
   padding: 0;
 }
+.octicon {
+  fill: var(--color-text-primary);
+}
+.mermaid {
+  display: flex;
+  justify-content: center;
+}
+.mermaid > svg {
+  max-width: none !important;
+}

--- a/app/_static/markdown.css
+++ b/app/_static/markdown.css
@@ -318,3 +318,8 @@
 .mermaid > svg {
   max-width: none !important;
 }
+.dot {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/app/pages/index.jsx
+++ b/app/pages/index.jsx
@@ -317,7 +317,9 @@ export default class PreviewPage extends React.Component {
           <script type="text/javascript" src="/_static/webfont.js"></script>
           <script type="text/javascript" src="/_static/snap.svg.min.js"></script>
           <script type="text/javascript" src="/_static/tweenlite.min.js"></script>
-          <script type="text/javascript" src="/_static/mermaid.min.js"></script>
+          <script type="module">
+            import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+          </script>
           <script type="text/javascript" src="/_static/sequence-diagram-min.js"></script>
           <script type="text/javascript" src="/_static/katex@0.15.3.js"></script>
           <script type="text/javascript" src="/_static/mhchem.min.js"></script>

--- a/app/pages/index.jsx
+++ b/app/pages/index.jsx
@@ -317,9 +317,7 @@ export default class PreviewPage extends React.Component {
           <script type="text/javascript" src="/_static/webfont.js"></script>
           <script type="text/javascript" src="/_static/snap.svg.min.js"></script>
           <script type="text/javascript" src="/_static/tweenlite.min.js"></script>
-          <script type="module">
-            import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
-          </script>
+          <script type="text/javascript" src="/_static/mermaid.min.js"></script>
           <script type="text/javascript" src="/_static/sequence-diagram-min.js"></script>
           <script type="text/javascript" src="/_static/katex@0.15.3.js"></script>
           <script type="text/javascript" src="/_static/mhchem.min.js"></script>

--- a/autoload/mkdp/autocmd.vim
+++ b/autoload/mkdp/autocmd.vim
@@ -1,6 +1,7 @@
 " init preview key action
 function! mkdp#autocmd#init() abort
-  execute 'augroup MKDP_REFRESH_INIT' . bufnr('%')
+  let s:bufnum = bufnr('%')
+  execute 'augroup MKDP_REFRESH_INIT' . s:bufnum
     autocmd!
     " refresh autocmd
     if g:mkdp_refresh_slow
@@ -10,13 +11,13 @@ function! mkdp#autocmd#init() abort
     endif
     " autoclose autocmd
     if g:mkdp_auto_close
-      autocmd BufHidden <buffer> call mkdp#rpc#preview_close()
+      autocmd BufHidden <buffer> call mkdp#rpc#preview_close(s:bufnum)
     endif
     " server close autocmd
     autocmd VimLeave * call mkdp#rpc#stop_server()
   augroup END
 endfunction
 
-function! mkdp#autocmd#clear_buf() abort
-  execute 'autocmd! ' . 'MKDP_REFRESH_INIT' . bufnr('%')
+function! mkdp#autocmd#clear_buf(bufnum) abort
+  execute 'autocmd! ' . 'MKDP_REFRESH_INIT' . a:bufnum
 endfunction

--- a/autoload/mkdp/rpc.vim
+++ b/autoload/mkdp/rpc.vim
@@ -109,18 +109,18 @@ function! mkdp#rpc#preview_refresh() abort
   endif
 endfunction
 
-function! mkdp#rpc#preview_close() abort
+function! mkdp#rpc#preview_close(bufnum) abort
   if s:is_vim
     if s:mkdp_channel_id !=# v:null
-      call mkdp#rpc#notify(s:mkdp_channel_id, 'close_page', { 'bufnr': bufnr('%') })
+      call mkdp#rpc#notify(s:mkdp_channel_id, 'close_page', { 'bufnr': a:bufnum })
     endif
   else
     if s:mkdp_channel_id !=# -1
-      call rpcnotify(s:mkdp_channel_id, 'close_page', { 'bufnr': bufnr('%') })
+      call rpcnotify(s:mkdp_channel_id, 'close_page', { 'bufnr': a:bufnum })
     endif
   endif
   let b:MarkdownPreviewToggleBool = 0
-  call mkdp#autocmd#clear_buf()
+  call mkdp#autocmd#clear_buf(a:bufnum)
 endfunction
 
 function! mkdp#rpc#open_browser() abort


### PR DESCRIPTION
**Problem:**
I would frequently get errors while closing previewing markdown buffers saying:
```
Error detected while processing BufHidden Autocommands for "<buffer=1>"..function mkdp#rpc#preview_close[11]..mkdp#autocmd#clear_buf:
line    1:
E216: No such group or event: MKDP_REFRESH_INIT10
```

This was because the auto-close autocmd would run after the buffer was already closed, and the plugin thought it needed to close my next opened buffer (some other non-markdown file) which of course was incorrect behavior.

**Solution:**
I fixed this by caching the buffer number of the actual markdown buffer I needed and then passing it down to each function that needed the buffer number to close it. I would really love to see this merged as this issue was quite annoying to me. Thanks for the great plugin