### PR TITLE
fix: image path issue with msys2/vim

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -82,6 +82,18 @@ use(async (req, res, next) => {
           }
         }
       }
+
+      const  home_prefix=process.env.MINGW_HOME;
+      if (home_prefix){
+        if(! imgPath.includes(':')){
+          // home_prefix is win-like:    E:\msys64\mingw32
+          // imgPath is unix-like:      /home/usrname/....
+          // the win-like full path of imgPath should be: E:\msys64\home\usrname\...
+          const parts = home_prefix.split("\\");
+          imgPath = path.join(parts[0],parts[1],imgPath)
+        }  
+      }
+
       logger.info('imgPath', imgPath)
       if (fs.existsSync(imgPath) && !fs.statSync(imgPath).isDirectory()) {
         if (imgPath.endsWith('svg')) {


### PR DESCRIPTION
1) Issue background
    a) on 'mingw32' terminal
    b) executable 'vim' in /usr/bin
    c) executable 'node' in /mingw32/bin.
    d) plugin 'markdow-preview.nvim' in ~/.vim/plugged
    e) app/route.js:68 fileDir is a  unix path
    f) image missing in browser preview
2) Issue fixing
    add code to app/route.js:
    a) extract info from environment variable MINGW_HOME
    b) prefixing imgPath with sth. like "E:\msys64\"
3) No issue alternative
    a) on 'ucrt64' terminal
    b) executable 'nvim' in /ucrt64/bin
    c) executable 'node' in /ucrt64/bin
    d) plugin 'markdown-preview.nvim' in ~/.vim/plugged
    e) app/route.js:68 fileDir is a win path
    f) image ok in browser preview