### PR TITLE
fix: program location in wsl (#309)

### DIFF
--- a/app/lib/util/opener.js
+++ b/app/lib/util/opener.js
@@ -8,6 +8,7 @@ const child_process_1 = tslib_1.__importDefault(require("child_process"));
 const os_1 = tslib_1.__importDefault(require("os"));
 module.exports = function opener(args, tool) {
     let platform = process.platform;
+    let is_wsl = false;
     args = [].concat(args);
     // Attempt to detect Windows Subystem for Linux (WSL).
     // WSL  itself as Linux (which works in most cases), but in
@@ -16,12 +17,18 @@ module.exports = function opener(args, tool) {
     // whereas using xdg-open does not, since there is no X Windows in WSL.
     if (platform === 'linux' && os_1.default.release().toLowerCase().indexOf('microsoft') !== -1) {
         platform = 'win32';
+        is_wsl = true;
     }
     // http://stackoverflow.com/q/1480971/3191, but see below for Windows.
     let command;
     switch (platform) {
         case 'win32': {
-            command = 'cmd.exe';
+            if (is_wsl) {
+                command = '/mnt/c/Windows/System32/cmd.exe';
+            }
+            else {
+                command = 'cmd.exe';
+            }
             if (tool) {
                 args.unshift(tool);
             }

--- a/src/util/opener.ts
+++ b/src/util/opener.ts
@@ -9,6 +9,7 @@ module.exports = function opener(
   tool: string | undefined
 ) {
   let platform = process.platform
+  let is_wsl = false
   args = [].concat(args)
 
   // Attempt to detect Windows Subystem for Linux (WSL).
@@ -18,13 +19,18 @@ module.exports = function opener(
   // whereas using xdg-open does not, since there is no X Windows in WSL.
   if (platform === 'linux' && os.release().toLowerCase().indexOf('microsoft') !== -1) {
     platform = 'win32'
+    is_wsl = true
   }
 
   // http://stackoverflow.com/q/1480971/3191, but see below for Windows.
   let command
   switch (platform) {
     case 'win32': {
-      command = 'cmd.exe'
+      if (is_wsl) {
+        command = '/mnt/c/Windows/System32/cmd.exe'
+      } else {
+        command = 'cmd.exe'
+      }
       if (tool) {
         args.unshift(tool)
       }


### PR DESCRIPTION
The absolute path of cmd.exe is a more stable choice in wsl.

Because some reasons like https://github.com/zdharma-continuum/fast-syntax-highlighting/issues/13, the Windows' PATH may not be totally add to wsl's PATH. But the absolute path of cmd.exe is often usable.