### PR TITLE
feat(css): Hide header and markdown border in print view

### DIFF
--- a/app/_static/markdown.css
+++ b/app/_static/markdown.css
@@ -309,3 +309,9 @@
   box-sizing: border-box;
   padding: 0;
 }
+
+@media print {
+  .markdown-body {
+    border: 0;
+  }
+}

--- a/app/_static/page.css
+++ b/app/_static/page.css
@@ -74,3 +74,10 @@ main {
   font-size: 14px;
   font-weight: 600;
 }
+
+@media print {
+  #page-header {
+    display: none;
+  }
+}
+


### PR DESCRIPTION
This adds CSS scoped to print media to hide the header and border around the markdown body.

I love this markdown preview, and I use it all the time. Often, to draft a document that I then print to PDF. Each time, I need to manually override the style to remove the header and border when printing, so I figured I'm perhaps not the only one so I would fix this.

This does only impact the style when printing.