### PR TITLE
Add mkdp_images_path_as_root (resolves #651)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ let g:mkdp_page_title = '「${name}」'
 " use a custom location for images
 let g:mkdp_images_path = /home/user/.markdown_images
 
+" resolve absolute image paths against the custom location for images,
+" instead of the root of the system (default to 0)
+let g:mkdp_images_path_as_root = 1
+
 " recognized filetypes
 " these filetypes will have MarkdownPreview... commands
 let g:mkdp_filetypes = ['markdown']

--- a/app/routes.js
+++ b/app/routes.js
@@ -93,7 +93,7 @@ use(async (req, res, next) => {
 
       let imgPath = decodeURIComponent(decodeURIComponent(req.asPath.replace(reg, '')))
       imgPath = imgPath.replace(/\\ /g, ' ')
-      if (imgPath[0] !== '/' && imgPath[0] !== '\\') {
+      if (req.custImgPathAsRoot || imgPath[0] !== '/' && imgPath[0] !== '\\') {
         imgPath = path.join(fileDir, imgPath)
       } else if (!fs.existsSync(imgPath)) {
         let tmpDirPath = fileDir

--- a/app/server.js
+++ b/app/server.js
@@ -44,6 +44,7 @@ exports.run = function () {
     req.mkcss = await plugin.nvim.getVar('mkdp_markdown_css')
     req.hicss = await plugin.nvim.getVar('mkdp_highlight_css')
     req.custImgPath = await plugin.nvim.getVar('mkdp_images_path')
+    req.custImgPathAsRoot = await plugin.nvim.getVar('mkdp_images_path_as_root')
     // routes
     routes(req, res)
   })

--- a/plugin/mkdp.vim
+++ b/plugin/mkdp.vim
@@ -105,6 +105,12 @@ if !exists('g:mkdp_images_path')
   let g:mkdp_images_path = ''
 endif
 
+" if 1, absolute image paths are resolved against the images custom
+" path instead of the system root
+if !exists('g:mkdp_images_path_as_root')
+  let g:mkdp_images_path_as_root = 0
+endif
+
 " combine preview window
 if !exists('g:mkdp_combine_preview')
   let g:mkdp_combine_preview = 0


### PR DESCRIPTION
As suggested in #651, `g:mkdp_images_path_as_root` can now be set to 1 to resolve absolute image paths against `g:mkdp_images_path`.

Example:
```
![Custom image](/path/to/image.png)
```
with `let g:mkdp_images_path = /home/user/.markdown_images`.

If `g:mkdp_images_path_as_root = 0` (default), then the image path is interpreted as an absolute linux path, starting at the root of the system.

If `g:mkdp_images_path_as_root = 1`, the path is interpreted as `/home/user/.markdown_images/path/to/image.png`.

This is notably useful to reproduce the behavior of markdown hosting websites, such as Github wikis, where absolute image paths are resolved against https://github.com/username/repository/wiki/.