### PR TITLE
fix(preview): use GitHub-style heading slugs

### DIFF
--- a/app/pages/index.jsx
+++ b/app/pages/index.jsx
@@ -24,6 +24,7 @@ import scrollToLine from './scroll'
 import { meta } from './meta';
 import markdownImSize from './markdown-it-imsize'
 import { escape} from './utils';
+import { createGithubSlugify } from './slugify'
 
 const anchorSymbol = '<svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>'
 
@@ -70,7 +71,8 @@ const DEFAULT_OPTIONS = {
   },
   uml: {},
   toc: {
-    listType: 'ul'
+    listType: 'ul',
+    uniqueSlugStartIndex: 2
   }
 }
 
@@ -180,6 +182,7 @@ export default class PreviewPage extends React.Component {
     content
   }) {
     if (!this.md) {
+      const slugify = createGithubSlugify()
       const {
         mkit = {},
         katex = {},
@@ -226,6 +229,7 @@ export default class PreviewPage extends React.Component {
         .use(flowchart, flowchartDiagrams)
         .use(dot)
         .use(markdownItAnchor, {
+          slugify,
           permalink: true,
           permalinkBefore: true,
           permalinkSymbol: anchorSymbol,
@@ -233,7 +237,8 @@ export default class PreviewPage extends React.Component {
         })
         .use(markdownItToc, {
           ...DEFAULT_OPTIONS.toc,
-          ...toc
+          ...toc,
+          slugify
         })
     }
 

--- a/app/pages/slugify.js
+++ b/app/pages/slugify.js
@@ -1,0 +1,5 @@
+import { slug as githubSlug } from 'github-slugger'
+
+export function createGithubSlugify() {
+  return (value) => githubSlug(value)
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@chemzqm/neovim": "^5.7.9",
     "chart.js": "^2.7.3",
+    "github-slugger": "^2.0.0",
     "highlight.js": "^10.4.1",
     "log4js": "^6.4.0",
     "markdown-it": "^12.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2698,6 +2698,11 @@ github-from-package@0.0.0:
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
   integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
+github-slugger@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-2.0.0.tgz#52cf2f9279a21eb6c59dd385b410f0c0adda8f1a"
+  integrity sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"


### PR DESCRIPTION
- switch markdown heading and TOC anchors to github-slugger
- align TOC duplicate suffixes with markdown-it-anchor numbering

Fixes: https://github.com/iamcco/markdown-preview.nvim/issues/191

similar pull request, but may out of date: https://github.com/iamcco/markdown-preview.nvim/pull/575

I'v tested with node v24.16.0, and it worked.

```bash
NODE_OPTIONS=--openssl-legacy-provider npx yarn install
NODE_OPTIONS=--openssl-legacy-provider npx yarn build
```